### PR TITLE
Update fileexcludefilters.cpp

### DIFF
--- a/src/file/fileexcludefilters.cpp
+++ b/src/file/fileexcludefilters.cpp
@@ -100,7 +100,15 @@ const char* const s_defaultFolderExcludeFilters[] = {
     //misc
     "core-dumps",
     "lost+found",
-
+   
+    // Javascript & co.
+    "node_modules",
+    "bower_components",
+    ".npm",
+    ".npm-cache",
+    ".yarn",
+    ".yarn-cache"
+      
     // end of list
     nullptr
 };


### PR DESCRIPTION
Added default exclusions for JS related folders which can contain tons of text files which probably nobody wants to have indexed.